### PR TITLE
Address build script issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build Status](https://github.com/upbcuk/upb.crypto.craco/workflows/Java%20CI/badge.svg)
+![Build Status](https://github.com/cryptimeleon/craco/workflows/Java%20CI/badge.svg)
 ## Craco
 
 Craco (CRyptogrAphic COnstructions) is a Java library providing implementations of various cryptographic primitives and low-level constructions. This includes primitives such as commitment schemes, signature schemes, facilities for implementing multi-party protocols, and much more.

--- a/build.gradle
+++ b/build.gradle
@@ -26,7 +26,7 @@ repositories {
 
 dependencies {
 
-    def mathVersion = '1.0.0' + (Boolean.valueOf(System.getProperty("disablesnapshot")) ? "" : "-SNAPSHOT")
+    def mathVersion = '1.0.0' + (isRelease ? "" : "-SNAPSHOT")
 
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api group: 'org.cryptimeleon', name: 'math', version: mathVersion
@@ -88,7 +88,6 @@ test {
 
 
 task javadocLatex(type: Javadoc) {
-
     source = sourceSets.main.allJava
     classpath = sourceSets.main.runtimeClasspath
     // enable rendering of umlauts
@@ -99,7 +98,10 @@ task javadocLatex(type: Javadoc) {
             "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.7/MathJax.js?" +
             "config=TeX-MML-AM_CHTML\"></script>"
     // reduce javadoc linting
-    options.addBooleanOption('Xdoclint:none', true)
+    //options.addBooleanOption('Xdoclint:none', true)
+    // link to math javadoc
+    options.addStringOption("link", "http://static.javadoc.io/org.cryptimeleon/math/latest/")
+    //options.addStringOption("J-Dhttp.agent=javadoc", "")
 }
 
 task javadocJar(type: Jar, dependsOn: javadocLatex) {

--- a/build.gradle
+++ b/build.gradle
@@ -23,10 +23,11 @@ repositories {
     jcenter()
 }
 
+def mathVersionNoSuffix = '1.0.0'
 
 dependencies {
 
-    def mathVersion = '1.0.0' + (isRelease ? "" : "-SNAPSHOT")
+    def mathVersion = mathVersionNoSuffix + (isRelease ? "" : "-SNAPSHOT")
 
     // This dependency is exported to consumers, that is to say found on their compile classpath.
     api group: 'org.cryptimeleon', name: 'math', version: mathVersion
@@ -92,6 +93,8 @@ task javadocLatex(type: Javadoc) {
     classpath = sourceSets.main.runtimeClasspath
     // enable rendering of umlauts
     options.addStringOption("charset", "UTF-8")
+    // link to math javadoc
+    options.addStringOption("link", "https://javadoc.io/doc/org.cryptimeleon/math/" + mathVersionNoSuffix)
     // enable latex rendering via mathjax
     options.addBooleanOption("-allow-script-in-comments", true)
     options.header = "<script type\"text/javascript&\" src=\"" +
@@ -99,9 +102,6 @@ task javadocLatex(type: Javadoc) {
             "config=TeX-MML-AM_CHTML\"></script>"
     // reduce javadoc linting
     //options.addBooleanOption('Xdoclint:none', true)
-    // link to math javadoc
-    options.addStringOption("link", "http://static.javadoc.io/org.cryptimeleon/math/latest/")
-    //options.addStringOption("J-Dhttp.agent=javadoc", "")
 }
 
 task javadocJar(type: Jar, dependsOn: javadocLatex) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ rootProject.name = 'craco'
 def msgPrefix = rootProject.name + " settings: "
 
 // do specific snapshot dependency resolution for snapshot builds
-if (!Boolean.valueOf(System.getProperty("release"))) {
+if (!Boolean.valueOf(getProperty("release"))) {
     def compositeLibraries = ["math"]
     for (String lib : compositeLibraries) {
         def libPrefix = "dependency " + lib

--- a/settings.gradle
+++ b/settings.gradle
@@ -7,7 +7,7 @@ rootProject.name = 'craco'
 def msgPrefix = rootProject.name + " settings: "
 
 // do specific snapshot dependency resolution for snapshot builds
-if (!Boolean.valueOf(getProperty("release"))) {
+if (!hasProperty("release")) {
     def compositeLibraries = ["math"]
     for (String lib : compositeLibraries) {
         def libPrefix = "dependency " + lib

--- a/src/main/java/org/cryptimeleon/craco/enc/AsymmetricEncryptionScheme.java
+++ b/src/main/java/org/cryptimeleon/craco/enc/AsymmetricEncryptionScheme.java
@@ -12,6 +12,7 @@ public interface AsymmetricEncryptionScheme extends EncryptionScheme {
 
     /**
      * Generates the key pair consisting of public and secret key.
+     * @return the resulting key pair
      */
     EncryptionKeyPair generateKeyPair();
 

--- a/src/main/java/org/cryptimeleon/craco/enc/asym/elgamal/ElgamalEncryption.java
+++ b/src/main/java/org/cryptimeleon/craco/enc/asym/elgamal/ElgamalEncryption.java
@@ -32,7 +32,6 @@ import java.util.Objects;
  * Decryption of c = (c_1, c_2) under private key sk = (G, g, a, h):
  * - The message is m = c_2 * c_1^{-a}
  * <p>
- * <p>
  * [1] T. Elgamal, "A public key cryptosystem and a signature scheme based on discrete logarithms," in IEEE Transactions
  * on Information Theory, vol. 31, no. 4, pp. 469-472, July 1985.
  */

--- a/src/main/java/org/cryptimeleon/craco/enc/asym/elgamal/ElgamalPrivateKey.java
+++ b/src/main/java/org/cryptimeleon/craco/enc/asym/elgamal/ElgamalPrivateKey.java
@@ -61,11 +61,12 @@ public class ElgamalPrivateKey implements DecryptionKey {
     }
 
     /**
-     * Creates a new Elgamal private-key
+     * Creates a new Elgamal private key.
      *
      * @param groupG the group
-     * @param g      a generator of the groupG
-     * @param a      the private exponent, where h := g^a
+     * @param g      a generator of the group {@code groupG}
+     * @param a      the private exponent such that \(h = g^a\)
+     * @param h      the public key \(h = g^a\)
      */
     public ElgamalPrivateKey(Group groupG, GroupElement g, ZnElement a, GroupElement h) {
         init(groupG, g, a, h);
@@ -105,7 +106,7 @@ public class ElgamalPrivateKey implements DecryptionKey {
      * Chooses a random exponent a in {0,....,n-1} and sets the private key to
      * g,a,h=g^a
      *
-     * @param groupG
+     * @param groupG the group over which ElGamal is done
      */
     public ElgamalPrivateKey(Group groupG) {
         init(groupG);

--- a/src/main/java/org/cryptimeleon/craco/kem/KeyEncapsulationMechanism.java
+++ b/src/main/java/org/cryptimeleon/craco/kem/KeyEncapsulationMechanism.java
@@ -30,32 +30,30 @@ import java.lang.reflect.Type;
  * @param <T> type of the encapsulated key
  */
 public interface KeyEncapsulationMechanism<T> extends StandaloneRepresentable, RepresentationRestorer {
-    public static class KeyAndCiphertext<T> {
+    class KeyAndCiphertext<T> {
         public T key;
         public CipherText encapsulatedKey;
     }
 
     /**
-     * Randomly chooses a key k and encrypts it
-     * w.r.t. the given pk. The result is (key, encapsulatedKey)
+     * Randomly chooses a key k and encrypts it using the given {@code pk}.
+     * The result is {@code (key, encapsulatedKey)}.
      *
      * @param pk public key used for encrypting k
      */
-    public KeyAndCiphertext<T> encaps(EncryptionKey pk);
+    KeyAndCiphertext<T> encaps(EncryptionKey pk);
 
     /**
-     * Takes an encapsulatedKey that was created by encaps()
-     * and decrypts it with sk.
-     * i.e. 	if (key, encapsulatedKey) <- encaps(pk);
-     * then decrypt(encapsulatedKey, sk) = key.
+     * Takes an encapsulated key that was created by {@code encaps()} and decrypts it with {@code sk}.
+     * That is, if {@code (key, encapsulatedKey) = encaps(pk)}, then {@code decrypt(encapsulatedKey, sk) == key}.
      */
-    public T decaps(CipherText encapsulatedKey, DecryptionKey sk) throws IllegalArgumentException;
+    T decaps(CipherText encapsulatedKey, DecryptionKey sk) throws IllegalArgumentException;
 
-    public CipherText restoreEncapsulatedKey(Representation repr);
+    CipherText restoreEncapsulatedKey(Representation repr);
 
-    public EncryptionKey restoreEncapsulationKey(Representation repr);
+    EncryptionKey restoreEncapsulationKey(Representation repr);
 
-    public DecryptionKey restoreDecapsulationKey(Representation repr);
+    DecryptionKey restoreDecapsulationKey(Representation repr);
 
     default Object restoreFromRepresentation(Type type, Representation repr) {
         if (type instanceof Class) {

--- a/src/main/java/org/cryptimeleon/craco/kem/asym/elgamal/ElgamalKEM.java
+++ b/src/main/java/org/cryptimeleon/craco/kem/asym/elgamal/ElgamalKEM.java
@@ -33,35 +33,42 @@ import java.util.Objects;
  * <p>
  * ElGamal:
  * <p>
- * Group G of size q, generator g, public key h=g^a, secret key a
+ * Group \(\mathbb{G}\) of size \(q\), generator \(g\), public key \(h=g^a\), secret key \(a\)
  * <p>
- * Encrypt Message R:
+ * Encrypt message \(R\):
+ * <ol>
+ * <li> Select \(s\) uniformly at random from \(\mathbb{Z}_q\)
+ * <li> Output ciphertext \(C=(R g^{as},g^s)\)
+ * </ol>
  * <p>
- * 1. select s UAR in Z_q 2. C=<R g^(as),g^s>
+ * Decrypt \(C\):
+ * <ol>
+ *  <li> Parse C as \(C=(C_1,C_2)\)
+ *  <li> Compute \(C_1 \cdot C_2^(-a)\)
+ * </ol>
  * <p>
- * Decrypt C:
+ * FOT Elgamal with KEM and \(H_1 : \mathbb{G} \times \{0,1\}^n \rightarrow \mathbb{Z}_q,
+ * H_2 : \mathbb{G} \rightarrow \{0,1\}^n\),
  * <p>
- * 1. Parse C as C=<C1,C2> 2. Compute C1*C2^(-a)
+ * Encaps \(k\):
+ * <ol>
+ *  <li> Select \(R\) uniformly at random from \(\mathbb{G}\) and \(k\) uniformly at random in \(\{0,1\}^n\),
+ *  and compute \(s=H(R,k)\) (commitment on \(R,k\))
+ *  <li> Elgamal encrypt \(R\) with random tape \(s\) to obtain \((C_1,C_2)\)
+ *  <li> One-time-pad encrypt \(k\) with \(r=H_2(R)\): \(C_3= r \oplus k\)
+ *  <li> Output \(C = (C_1, C_2, C_3)\)
+ * </ol>
  * <p>
- * <p>
- * FOT Elgamal with KEM and H1:Gx{0,1}^n->Z_q, H2:G->{0,1}^n,
- * <p>
- * Encaps k:
- * <p>
- * 1. select R UAR in G and k UAR in {0,1}^n, compute s=H(R,k) (commitment on
- * R,k) 2. Elgamal Encrypt R with random tape s to obtain C=<C1,C2> 3. OTP
- * encrypt k with r=H2(R): C2= r xor k
- * <p>
- * Decaps k: 1. Parse C=<C1,C2,C3> 2. Elgamal Decrypt <C1,C2> to obtain R' 3.
- * OTP Decrypt C3 with H2(R) to obtain k' 4. recover commitment s'=H1(R',k') 5.
- * check commitment by ElGamal encryption R' with s' and comparison with C1 a.
- * if ok, return k' b. otherwithe return fail
- * <p>
- * <p>
- * This implementation uses org.cryptimeleon.craco.enc.asym.elgamal for Elgamal
- * Encryption
- *
- *
+ * Decaps \(k\):
+ * <ol>
+ *  <li> Parse \(C=(C_1,C_2,C_3)\)
+ *  <li> Elgamal decrypt \((C_1,C_2)\) to obtain message \(R'\)
+ *  <li> One-time-pad decrypt \(C_3\) with \(H_2(R)\) to obtain \(k'\)
+ *  <li> Recover commitment \(s'=H_1(R',k')\)
+ *  <li> Check commitment by ElGamal encrypting \(R'\) with \(s'\) and comparing it with \(C_1 \cdot a\).
+ *       If ok, return \(k' \cdot b\). Otherwise return fail
+ * </ol>
+ * @see ElgamalEncryption
  */
 
 

--- a/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/SchnorrFragment.java
+++ b/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/SchnorrFragment.java
@@ -35,13 +35,11 @@ import org.cryptimeleon.math.serialization.Representation;
  * <p>
  *     Note that the second and third fragment share the same {@code w} and {@code r}. This dependency is expressed in this interface:
  *     a {@linkplain SchnorrFragment}'s trascript generation may depend on variables that are outside of its own control. We call those variables "external" variables.
- * </p>
  *
  * <p>
  *     This approach allows for easy composition of fragments that depend on (some of) the same variables.
  *     However, this also means that {@linkplain SchnorrFragment}s are basically useless by themselves because they depend on external variables.
  *     To ultimately make use of a {@linkplain SchnorrFragment} in an actual protocol, implement a {@link SendThenDelegateProtocol} and use the fragment as a subprotocol.
- * </p>
  *
  * <p>
  *     Implementing classes are usually used as follows:
@@ -62,12 +60,10 @@ import org.cryptimeleon.math.serialization.Representation;
  *         <li>Verifier checks {@code checkTranscript(A, c, R, externalResponse)}</li>
  *     </ul>
  *     using the standard (response0-response1)/(challenge0-challenge1) knowledge extractor.
- * </p>
  *
  * <p>
  *     Most {@linkplain SchnorrFragment}s will probably be implemented by extending {@link DelegateFragment} or {@link SendThenDelegateFragment}.
  *     To compose a bunch of {@linkplain SchnorrFragment}s into a {@link SigmaProtocol}, see {@link DelegateProtocol} or {@link SendThenDelegateProtocol}.
- * </p>
  */
 public interface SchnorrFragment {
     /**

--- a/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/setmembership/SmallerThanPowerFragment.java
+++ b/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/setmembership/SmallerThanPowerFragment.java
@@ -15,7 +15,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * A fragment to prove a statement of the form \(0 \leq \text{member} < \text{base}^\text{power}\).
+ * A fragment to prove a statement of the form \(0 \leq \text{member} &#60; \text{base}^\text{power}\).
  */
 public class SmallerThanPowerFragment extends DelegateFragment {
     protected final int base;

--- a/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/setmembership/TwoSidedRangeProof.java
+++ b/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/setmembership/TwoSidedRangeProof.java
@@ -12,7 +12,7 @@ import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
 /**
- * A fragment for the statement "lowerBound <= member <= upperBound".
+ * A fragment for the statement {@code lowerBound <= member <= upperBound}.
  */
 public class TwoSidedRangeProof extends DelegateFragment {
     private final ExponentExpr member;

--- a/src/main/java/org/cryptimeleon/craco/secretsharing/shamir/ShamirSecretSharing.java
+++ b/src/main/java/org/cryptimeleon/craco/secretsharing/shamir/ShamirSecretSharing.java
@@ -24,7 +24,7 @@ import java.util.stream.IntStream;
  * such that \(P(0)=s\).
  * <p>
  * The shares \((i, s_i = P(i))\) correspond to data points on the polynomial therefore any set \(S\) of shares
- * with \(|S| >= t\) can be used to uniquely determine the original polynomial using interpolation and therefore
+ * with \(|S| \geq t\) can be used to uniquely determine the original polynomial using interpolation and therefore
  * reconstruct
  * the secret.
  * <p>


### PR DESCRIPTION
## Changes

- replace remaining "disablesnapshot" usage with "release"
- fix `settings.gradle` script to use project property "release" not system property
- turn on javadoc linting back on for gradle task `javadocLatex` and fix remaining errors
- Link math javadoc hosted on javadoc.io such that references to math classes are linked to the math javadocs

Would be interested to know if we can update the craco javadoc jar without incrementing the version number...