### PR TITLE
Add multi-message sign and verify default methods

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,22 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Pointcheval & Sanders' signature schemes from "Reassessing Security of Randomizable Signatures", 2018
-- Fuchsbauer, Hanser and Slamanig's signature scheme from "Structur-Preserving Signatures on Equivalence Classes and Constant-Size Anonymous Credentials", 2014
+- Helper methods for `MultiMessageSignatureScheme` and `StructurePreservingSignatureEQScheme` to make signing and verifying multiple plaintexts less verbose
 
-### Changed
-- Reordered many packages to improve organization
-- Updated Gradle to version 6.4
+## [1.0.0] - 2021-03-01
 
-### Fixed
+Initial release
 
-### Removed
-- ABE and ABE-KEM schemes as they have been moved to the [Predenc library](https://github.com/upbcuk/upb.crypto.predenc)
-- Log4j dependency
-- Json-simple dependency
-- Key derivation functions
-- `ByteArrayQueue` and `Triple` classes (not used)
-- `interaction` package (not used)
-- `PrimeFieldPolynomial` and `SecureRandomGenerator` classes (replaced by other functionality)
-- `WatersHash` class (moved to Predenc project) and `LagrangeUtil` class (moved to Math project)
-- Author tags
+[Unreleased]: https://github.com/cryptimeleon/craco/compare/v1.0.0...HEAD
+[1.0.0]: https://github.com/cryptimeleon/craco/releases/tag/v1.0.0

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 group = 'org.cryptimeleon'
 archivesBaseName = project.name
 boolean isRelease = project.hasProperty("release")
-version = '1.0.0'  + (isRelease ? "" : "-SNAPSHOT")
+version = '1.1.0'  + (isRelease ? "" : "-SNAPSHOT")
 
 
 sourceCompatibility = 1.8

--- a/src/main/java/org/cryptimeleon/craco/sig/MultiMessageSignatureScheme.java
+++ b/src/main/java/org/cryptimeleon/craco/sig/MultiMessageSignatureScheme.java
@@ -42,7 +42,7 @@ public interface MultiMessageSignatureScheme extends SignatureScheme {
      * @param plainTexts plaintexts to sign
      * @return signature over the given vector of plaintexts
      */
-    default Signature sign(SigningKey secretKey, Vector<PlainText> plainTexts) {
+    default Signature sign(SigningKey secretKey, Vector<? extends PlainText> plainTexts) {
         return sign(new MessageBlock(plainTexts), secretKey);
     }
 
@@ -53,7 +53,7 @@ public interface MultiMessageSignatureScheme extends SignatureScheme {
      * @param plainTexts vector of plaintexts to verify signature for
      * @return true if verification succeeds, else false
      */
-    default Boolean verify(VerificationKey publicKey, Signature signature, Vector<PlainText> plainTexts) {
+    default Boolean verify(VerificationKey publicKey, Signature signature, Vector<? extends PlainText> plainTexts) {
         return verify(new MessageBlock(plainTexts), signature, publicKey);
     }
 }

--- a/src/main/java/org/cryptimeleon/craco/sig/MultiMessageSignatureScheme.java
+++ b/src/main/java/org/cryptimeleon/craco/sig/MultiMessageSignatureScheme.java
@@ -1,6 +1,8 @@
 package org.cryptimeleon.craco.sig;
 
 import org.cryptimeleon.craco.common.plaintexts.MessageBlock;
+import org.cryptimeleon.craco.common.plaintexts.PlainText;
+import org.cryptimeleon.math.structures.cartesian.Vector;
 
 /**
  * A {@code MultiMessageSignatureScheme} is one where the sign and verify algorithms take a list of messages as input
@@ -10,9 +12,48 @@ import org.cryptimeleon.craco.common.plaintexts.MessageBlock;
  * where the signed message is of type {@link MessageBlock}.
  * <p>
  * This interface introduces some helper methods for this case.
- *
- *
  */
 public interface MultiMessageSignatureScheme extends SignatureScheme {
 
+    /**
+     * Signs multiple messages as a single unit.
+     * @param secretKey key to sign with
+     * @param plainTexts plaintexts to sign
+     * @return signature over the given plaintexts
+     */
+    default Signature sign(SigningKey secretKey, PlainText... plainTexts) {
+        return sign(new MessageBlock(plainTexts), secretKey);
+    }
+
+    /**
+     * Verifies a signature for multiple messages.
+     * @param publicKey key to use for verification
+     * @param signature signature to verify
+     * @param plainTexts plaintexts to verify signature for
+     * @return true if verification succeeds, else false
+     */
+    default Boolean verify(VerificationKey publicKey, Signature signature, PlainText... plainTexts) {
+        return verify(new MessageBlock(plainTexts), signature, publicKey);
+    }
+
+    /**
+     * Signs the given vector of plaintexts.
+     * @param secretKey key to sign with
+     * @param plainTexts plaintexts to sign
+     * @return signature over the given vector of plaintexts
+     */
+    default Signature sign(SigningKey secretKey, Vector<PlainText> plainTexts) {
+        return sign(new MessageBlock(plainTexts), secretKey);
+    }
+
+    /**
+     * Verifies a signature for a vector of plaintexts.
+     * @param publicKey key to use for verification
+     * @param signature signature to verify
+     * @param plainTexts vector of plaintexts to verify signature for
+     * @return true if verification succeeds, else false
+     */
+    default Boolean verify(VerificationKey publicKey, Signature signature, Vector<PlainText> plainTexts) {
+        return verify(new MessageBlock(plainTexts), signature, publicKey);
+    }
 }

--- a/src/main/java/org/cryptimeleon/craco/sig/StructurePreservingSignatureEQScheme.java
+++ b/src/main/java/org/cryptimeleon/craco/sig/StructurePreservingSignatureEQScheme.java
@@ -1,7 +1,6 @@
 package org.cryptimeleon.craco.sig;
 
 
-import com.sun.org.apache.bcel.internal.generic.RETURN;
 import org.cryptimeleon.craco.common.plaintexts.GroupElementPlainText;
 import org.cryptimeleon.craco.common.plaintexts.MessageBlock;
 import org.cryptimeleon.craco.common.plaintexts.PlainText;

--- a/src/main/java/org/cryptimeleon/craco/sig/StructurePreservingSignatureEQScheme.java
+++ b/src/main/java/org/cryptimeleon/craco/sig/StructurePreservingSignatureEQScheme.java
@@ -89,7 +89,7 @@ public interface StructurePreservingSignatureEQScheme extends StandardMultiMessa
     default Signature sign(SigningKey secretKey, GroupElementVector groupElements) {
         return sign(
                 new MessageBlock(groupElements.map(
-                    (Function<GroupElement, GroupElementPlainText>) GroupElementPlainText::new
+                        (Function<GroupElement, GroupElementPlainText>) GroupElementPlainText::new
                 )),
                 secretKey
         );

--- a/src/main/java/org/cryptimeleon/craco/sig/StructurePreservingSignatureEQScheme.java
+++ b/src/main/java/org/cryptimeleon/craco/sig/StructurePreservingSignatureEQScheme.java
@@ -1,8 +1,15 @@
 package org.cryptimeleon.craco.sig;
 
 
+import com.sun.org.apache.bcel.internal.generic.RETURN;
+import org.cryptimeleon.craco.common.plaintexts.GroupElementPlainText;
+import org.cryptimeleon.craco.common.plaintexts.MessageBlock;
 import org.cryptimeleon.craco.common.plaintexts.PlainText;
+import org.cryptimeleon.math.structures.groups.GroupElement;
+import org.cryptimeleon.math.structures.groups.cartesian.GroupElementVector;
 import org.cryptimeleon.math.structures.rings.zn.Zn;
+
+import java.util.function.Function;
 
 /**
  * A structure-preserving signature scheme on equivalence classes (SPS-EQ).
@@ -52,4 +59,57 @@ public interface StructurePreservingSignatureEQScheme extends StandardMultiMessa
      * and the given scalar {@code mu}.
      */
     PlainText chgRepMessage(PlainText plainText, Zn.ZnElement mu);
+
+    /**
+     * Signs multiple group elements as a single unit.
+     * @param secretKey key to sign with
+     * @param groupElements group elements to sign
+     * @return signature over the given plaintexts
+     */
+    default Signature sign(SigningKey secretKey, GroupElement... groupElements) {
+        return sign(secretKey, new GroupElementVector(groupElements));
+    }
+
+    /**
+     * Verifies a signature for multiple messages.
+     * @param verificationKey key to use for verification
+     * @param signature signature to verify
+     * @param groupElements group elements to verify signature for
+     * @return true if verification succeeds, else false
+     */
+    default Boolean verify(VerificationKey verificationKey, Signature signature, GroupElement... groupElements) {
+        return verify(verificationKey, signature, new GroupElementVector(groupElements));
+    }
+
+    /**
+     * Signs the given vector of group elements.
+     * @param secretKey key to sign with
+     * @param groupElements vector of group elements to sign
+     * @return signature over the given vector of plaintexts
+     */
+    default Signature sign(SigningKey secretKey, GroupElementVector groupElements) {
+        return sign(
+                new MessageBlock(groupElements.map(
+                    (Function<GroupElement, GroupElementPlainText>) GroupElementPlainText::new
+                )),
+                secretKey
+        );
+    }
+
+    /**
+     * Verifies a signature for a vector of group elements.
+     * @param verificationKey key to use for verification
+     * @param signature signature to verify
+     * @param groupElements vector of group elements to verify signature for
+     * @return true if verification succeeds, else false
+     */
+    default Boolean verify(VerificationKey verificationKey, Signature signature, GroupElementVector groupElements) {
+        return verify(
+                new MessageBlock(groupElements.map(
+                        (Function<GroupElement, GroupElementPlainText>) GroupElementPlainText::new
+                )),
+                signature,
+                verificationKey
+        );
+    }
 }


### PR DESCRIPTION
## Added
- Multi-message sign and verify default methods for the `MultiMessageSignatureScheme` and `StructurePreservingSignatureEQScheme` interfaces
- Information about above changes are added to changelog

## Changed
- Version Number increased to 1.1.0 since above changes represent a backward-compatible API change ("Minor version Y (x.Y.z | x > 0) MUST be incremented if new, backwards compatible functionality is introduced to the public API").