### PR TITLE
Make javadocLatex only link math javadocs when release is set

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -94,7 +94,9 @@ task javadocLatex(type: Javadoc) {
     // enable rendering of umlauts
     options.addStringOption("charset", "UTF-8")
     // link to math javadoc
-    options.addStringOption("link", "https://javadoc.io/doc/org.cryptimeleon/math/" + mathVersionNoSuffix)
+    if (isRelease) {
+        options.addStringOption("link", "https://javadoc.io/doc/org.cryptimeleon/math/" + mathVersionNoSuffix)
+    }
     // enable latex rendering via mathjax
     options.addBooleanOption("-allow-script-in-comments", true)
     options.header = "<script type\"text/javascript&\" src=\"" +


### PR DESCRIPTION
If you try and build the current version of craco, it won't work because the javadoc linking will try and link to a math version on javadoc.io that does not exist yet (version 2.0.0). The linking should only be done for release versions as there we can guarantee that math exists already by releasing math first.