### PR TITLE
Fixed GCM padding

### DIFF
--- a/src/main/java/org/cryptimeleon/craco/enc/sym/streaming/aes/StreamingGCMAESPacketMode.java
+++ b/src/main/java/org/cryptimeleon/craco/enc/sym/streaming/aes/StreamingGCMAESPacketMode.java
@@ -52,7 +52,7 @@ public class StreamingGCMAESPacketMode implements StreamingEncryptionScheme {
 
     private byte[] initialVector = new byte[initialVectorLength / 8];
 
-    private final String transformation = "AES/GCM/PKCS5Padding";
+    private final String transformation = "AES/GCM/NoPadding";
     
     private final int packetSize;
 


### PR DESCRIPTION
This caused an exception while running `gradle test` for me: "GCM mode must be used with NoPadding".