### PR TITLE
Replace usages of getInteger with asInteger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Changed uses `Zn#getInteger()` from Math library to `RingElement#asInteger()` to address removal of the former from the Math library
+
 ## [2.1.0]
 
 ### Added

--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 group = 'org.cryptimeleon'
 archivesBaseName = project.name
 boolean isRelease = project.hasProperty("release")
-version = '2.1.0'  + (isRelease ? "" : "-SNAPSHOT")
+version = '3.0.0'  + (isRelease ? "" : "-SNAPSHOT")
 
 
 sourceCompatibility = 1.8
@@ -22,7 +22,7 @@ repositories {
     mavenCentral()
 }
 
-def mathVersionNoSuffix = '2.1.0'
+def mathVersionNoSuffix = '3.0.0'
 
 dependencies {
 

--- a/src/main/java/org/cryptimeleon/craco/enc/asym/elgamal/ElgamalEncryption.java
+++ b/src/main/java/org/cryptimeleon/craco/enc/asym/elgamal/ElgamalEncryption.java
@@ -60,7 +60,7 @@ public class ElgamalEncryption implements AsymmetricEncryptionScheme {
         Zn zn_random = new Zn(sizeG);
         ZnElement random_zn_element = zn_random.getUniformlyRandomElement();
 
-        return this.encrypt(plainText, publicKey, random_zn_element.getInteger());
+        return this.encrypt(plainText, publicKey, random_zn_element.asInteger());
     }
 
     /**

--- a/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/setmembership/SetMembershipFragment.java
+++ b/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/setmembership/SetMembershipFragment.java
@@ -40,9 +40,9 @@ public class SetMembershipFragment extends SendThenDelegateFragment {
         Zn.ZnElement memberVal = member.evaluate(pp.getZn(), externalWitnesses);
 
         //Pick the right signature for memberVal
-        if (!pp.signatures.containsKey(memberVal.getInteger()))
-            throw new IllegalArgumentException("Proposed member value "+ memberVal.getInteger() +" is not actually in the set. Illegal witness.");
-        GroupElement signature = pp.signatures.get(memberVal.getInteger());
+        if (!pp.signatures.containsKey(memberVal.asInteger()))
+            throw new IllegalArgumentException("Proposed member value "+ memberVal.asInteger() +" is not actually in the set. Illegal witness.");
+        GroupElement signature = pp.signatures.get(memberVal.asInteger());
 
         //Blind signature with blinding value
         GroupElement blindedSignature = signature.pow(r);

--- a/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/setmembership/SmallerThanPowerFragment.java
+++ b/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/setmembership/SmallerThanPowerFragment.java
@@ -57,7 +57,7 @@ public class SmallerThanPowerFragment extends DelegateFragment {
         Zn.ZnElement memberVal = this.member.evaluate(pp.getZn(), externalWitnesses);
 
         //Decompose memberVal into digits
-        BigInteger[] digits = IntegerRing.decomposeIntoDigits(memberVal.getInteger(), BigInteger.valueOf(base), power);
+        BigInteger[] digits = IntegerRing.decomposeIntoDigits(memberVal.asInteger(), BigInteger.valueOf(base), power);
 
         //Add digits to witnesses
         for (int i=0; i<power; i++)

--- a/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/setmembership/TwoSidedRangeProof.java
+++ b/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/setmembership/TwoSidedRangeProof.java
@@ -37,7 +37,7 @@ public class TwoSidedRangeProof extends DelegateFragment {
         this.pp = pp;
 
         this.base = pp.signatures.size();
-        BigInteger intervalSize = upperBound.getInteger().subtract(lowerBound.getInteger());
+        BigInteger intervalSize = upperBound.asInteger().subtract(lowerBound.asInteger());
         if (intervalSize.signum() < 0)
             throw new IllegalArgumentException("upper bound must be larger than lower bound");
 
@@ -47,7 +47,7 @@ public class TwoSidedRangeProof extends DelegateFragment {
 
         this.power = power;
 
-        if (lowerBound.getInteger().add(BigInteger.valueOf(base).pow(power)).compareTo(pp.getZn().size()) > 0)
+        if (lowerBound.asInteger().add(BigInteger.valueOf(base).pow(power)).compareTo(pp.getZn().size()) > 0)
             throw new IllegalArgumentException("Interval is too close to the mod p overflow boundary (i.e. numbers in the interval are too large - choose smaller numbers)");
     }
 

--- a/src/main/java/org/cryptimeleon/craco/secretsharing/accessstructure/MonotoneSpanProgram.java
+++ b/src/main/java/org/cryptimeleon/craco/secretsharing/accessstructure/MonotoneSpanProgram.java
@@ -138,7 +138,7 @@ public class MonotoneSpanProgram extends AccessStructure {
             output = output.concat("( ");
             for (ZpElement entry : row) {
                 columnCounter++;
-                output = output.concat(String.format("%3d ", entry.getInteger().shortValue()));
+                output = output.concat(String.format("%3d ", entry.asInteger().shortValue()));
             }
 
             for (; columnCounter <= size; columnCounter++) {

--- a/src/main/java/org/cryptimeleon/craco/sig/ps/PSSignatureScheme.java
+++ b/src/main/java/org/cryptimeleon/craco/sig/ps/PSSignatureScheme.java
@@ -102,7 +102,7 @@ public class PSSignatureScheme implements StandardMultiMessageSignatureScheme {
         );
 
         // second element of signature, sigma_2 in paper
-        GroupElement group1ElementSigma2 = group1ElementH.pow(resultExponent.getInteger()).compute();
+        GroupElement group1ElementSigma2 = group1ElementH.pow(resultExponent.asInteger()).compute();
 
         return new PSSignature(group1ElementH, group1ElementSigma2);
     }

--- a/src/main/java/org/cryptimeleon/craco/sig/ps18/PS18SignatureScheme.java
+++ b/src/main/java/org/cryptimeleon/craco/sig/ps18/PS18SignatureScheme.java
@@ -192,7 +192,7 @@ public class PS18SignatureScheme implements SignatureScheme {
                 sk.getExponentsYi().get(sk.getNumberOfMessages()).mul(exponentPrimeM)
         );
         // Now we exponentiate h with the exponent and return that as sigma_2.
-        return sigma1.pow(resultExponent.getInteger());
+        return sigma1.pow(resultExponent.asInteger());
     }
 
     /**


### PR DESCRIPTION
This matches Craco with the recent `develop` version of Math. Also increment version to 3.0.0, since we export Math as an API dependency, and therefore changing the API of Math also changes the API of Craco (at least that is my interpretation of semver).