### PR TITLE
Fix exception message formatting error

### DIFF
--- a/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/SendThenDelegateFragment.java
+++ b/src/main/java/org/cryptimeleon/craco/protocols/arguments/sigma/schnorr/SendThenDelegateFragment.java
@@ -530,7 +530,7 @@ public abstract class SendThenDelegateFragment implements SchnorrFragment {
 
             subprotocolSpec.forEachVariable((name, var) -> {
                 if (!witnessesForVariables.containsKey(name))
-                    throw new IllegalStateException("Witness for " + name + "is missing");
+                    throw new IllegalStateException("Witness for " + name + " is missing");
             });
 
             return new WitnessValues(witnessesForVariables);


### PR DESCRIPTION
In  SendThenDelegateFragment, a space between the name of a missing witness variable name and the text of the exception message was missing.
For example, if the missing variable's name is "t", the output is "Witness for tis missing".