### PR TITLE
Switch to a natively supported curve for android.

### DIFF
--- a/src/main/java/org/cryptimeleon/craco/sig/ecdsa/ECDSASignatureScheme.java
+++ b/src/main/java/org/cryptimeleon/craco/sig/ecdsa/ECDSASignatureScheme.java
@@ -22,7 +22,7 @@ import java.util.Objects;
 public class ECDSASignatureScheme implements SignatureScheme {
 
     static final String ALGORITHM = "EC";
-    static final String CURVE = "secp256k1";
+    static final String CURVE = "secp256r1";
     private static final String SIGNING_ALGORITHM = "SHA256withECDSA";
     private final Signature signer;
 


### PR DESCRIPTION
It turned out that secp256k1 is not supported on android (at least not natively). secp256r1 works, so let's switch to that curve.